### PR TITLE
Add to-do list, with entries pointing to the CTAs

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "react-dom": "^15.4.0",
     "react-redux": "^4.4.6",
     "redux": "^3.6.0",
+    "redux-little-router": "^12.0.0",
     "style-loader": "^0.13.1",
     "uuid": "^3.0.0",
     "webpack": "^1.13.3"

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "react-redux": "^4.4.6",
     "redux": "^3.6.0",
     "style-loader": "^0.13.1",
+    "uuid": "^3.0.0",
     "webpack": "^1.13.3"
   },
   "repository": {

--- a/src/actions.js
+++ b/src/actions.js
@@ -1,0 +1,10 @@
+export const ADD_TODO = 'ADD_TODO';
+export const TOGGLE_TODO = 'TOGGLE_TODO';
+
+export function addTodo(actionId) {
+  return { type: ADD_TODO, actionId };
+}
+
+export function toggleTodo(uid) {
+  return { type: TOGGLE_TODO, uid };
+}

--- a/src/client/index.jsx
+++ b/src/client/index.jsx
@@ -3,10 +3,12 @@
 
 import React from 'react';
 import { render } from 'react-dom';
-import { createStore } from 'redux';
+import { createStore, compose, applyMiddleware } from 'redux';
 import { Provider } from 'react-redux';
+import { RouterProvider, routerForBrowser } from 'redux-little-router';
 
 import App from '../components/App';
+import routes from '../routes';
 import reducer from '../reducer';
 
 // Grab the state from a global injected into server-generated HTML
@@ -14,15 +16,24 @@ import reducer from '../reducer';
 const preloadedState = window.__PRELOADED_STATE__;
 /* eslint-enable */
 
+const { routerEnhancer, routerMiddleware } = routerForBrowser({ routes });
+
 // Create Redux store with initial state
 /* eslint-disable no-underscore-dangle */
 const store = createStore(reducer, preloadedState,
-  window.__REDUX_DEVTOOLS_EXTENSION__ && window.__REDUX_DEVTOOLS_EXTENSION__());
+  compose(
+    routerEnhancer,
+    applyMiddleware(routerMiddleware),
+    window.__REDUX_DEVTOOLS_EXTENSION__ && window.__REDUX_DEVTOOLS_EXTENSION__(),
+  ),
+);
 /* eslint-enable */
 
 render(
   <Provider store={store}>
-    <App />
+    <RouterProvider store={store}>
+      <App />
+    </RouterProvider>
   </Provider>,
   document.getElementById('root'),
 );

--- a/src/components/AddTodo/index.jsx
+++ b/src/components/AddTodo/index.jsx
@@ -6,7 +6,7 @@ import styles from './styles.css';
 const AddTodo = ({onClick, actionId, todo}) => {
   let text = "+"
   if (todo) {
-    text = todo.completed ? "☑" : "☐"
+    text = todo.completed ? "☑" : ""
   }
   return (
     <button styleName='add-todo' onClick={function() {onClick(actionId)}}>

--- a/src/components/AddTodo/index.jsx
+++ b/src/components/AddTodo/index.jsx
@@ -1,0 +1,24 @@
+import React, { PropTypes } from 'react'
+import CSSModules from 'react-css-modules';
+
+import styles from './styles.css';
+
+const AddTodo = ({onClick, actionId, todo}) => {
+  let text = "+"
+  if (todo) {
+    text = todo.completed ? "☑" : "☐"
+  }
+  return (
+    <button styleName='add-todo' onClick={function() {onClick(actionId)}}>
+      {text}
+    </button>
+  )
+}
+
+AddTodo.propTypes = {
+  onClick: PropTypes.func.isRequired,
+  actionId: PropTypes.string.isRequired,
+  todo: PropTypes.object.isRequired
+}
+
+export default CSSModules(AddTodo, styles);

--- a/src/components/AddTodo/index.jsx
+++ b/src/components/AddTodo/index.jsx
@@ -18,7 +18,7 @@ const AddTodo = ({onClick, actionId, todo}) => {
 AddTodo.propTypes = {
   onClick: PropTypes.func.isRequired,
   actionId: PropTypes.string.isRequired,
-  todo: PropTypes.object.isRequired
+  todo: PropTypes.object
 }
 
 export default CSSModules(AddTodo, styles);

--- a/src/components/AddTodo/styles.css
+++ b/src/components/AddTodo/styles.css
@@ -1,0 +1,5 @@
+.add-todo {
+    position: absolute;
+    top: 2vh;
+    right: 2vh;
+}

--- a/src/components/App/index.jsx
+++ b/src/components/App/index.jsx
@@ -5,6 +5,7 @@ import _ from 'lodash';
 import { connect } from 'react-redux';
 import CSSModules from 'react-css-modules';
 
+import TodoList from '../../containers/TodoList';
 import CallToAction from '../CallToAction';
 import StructuredText from '../StructuredText';
 import styles from './styles.css';
@@ -23,6 +24,8 @@ const App = ({ callsToAction, startHere }) => (
         <CallToAction {...callToAction.data} uid={callToAction.uid} key={callToAction.uid} />
       ))}
     </div>
+
+    <TodoList />
 
     <div id="start-here" styleName="start-here">
       <h2>{startHere.data['start-here.title'].value}</h2>

--- a/src/components/App/index.jsx
+++ b/src/components/App/index.jsx
@@ -4,6 +4,7 @@ import React, { PropTypes } from 'react';
 import _ from 'lodash';
 import { connect } from 'react-redux';
 import CSSModules from 'react-css-modules';
+import { Link, AbsoluteFragment as Fragment } from 'redux-little-router';
 
 import TodoList from '../../containers/TodoList';
 import CallToAction from '../CallToAction';
@@ -15,17 +16,23 @@ const App = ({ callsToAction, startHere }) => (
     <h1 id="title" styleName="title">{startHere.data['start-here.page-title'].value}</h1>
     <h2 styleName="subtitle">{startHere.data['start-here.subtitle'].value}</h2>
 
+    <Link href="/todo">Todos</Link>
+
     <div id="intro" styleName="intro">
       <a styleName="link-button" href="#start-here">{startHere.data['start-here.button-text'].value}</a>
     </div>
 
-    <div id="calls-to-action">
-      {callsToAction.map(callToAction => (
-        <CallToAction {...callToAction.data} uid={callToAction.uid} key={callToAction.uid} />
-      ))}
-    </div>
+    <Fragment forRoute="/">
+      <div id="calls-to-action">
+        {callsToAction.map(callToAction => (
+          <CallToAction {...callToAction.data} uid={callToAction.uid} key={callToAction.uid} />
+        ))}
+      </div>
+    </Fragment>
 
-    <TodoList />
+    <Fragment forRoute="/todo">
+      <TodoList />
+    </Fragment>
 
     <div id="start-here" styleName="start-here">
       <h2>{startHere.data['start-here.title'].value}</h2>

--- a/src/components/CallToAction/index.jsx
+++ b/src/components/CallToAction/index.jsx
@@ -1,6 +1,7 @@
 import React, { PropTypes } from 'react';
 import CSSModules from 'react-css-modules';
 
+import AddTodo from '../../containers/AddTodo';
 import StructuredText from '../StructuredText';
 import PhoneNumbers from '../PhoneNumbers';
 import styles from './styles.css';
@@ -10,6 +11,8 @@ const CallToAction = props => (
     <h1>{props['call-to-action.title'].value[0].text}</h1>
 
     <time>{props['call-to-action.date'].value}</time>
+
+    <AddTodo actionId={props.uid} />
 
     {props['call-to-action.phone-numbers'] && <PhoneNumbers {...props['call-to-action.phone-numbers']} />}
 

--- a/src/components/CallToAction/styles.css
+++ b/src/components/CallToAction/styles.css
@@ -2,6 +2,7 @@
     margin: 0.5vh 2vh 2vh;
     border: 1px solid grey;
     background: white;
+    position: relative;
 }
 
 .call-to-action h1 {

--- a/src/components/Todo/index.jsx
+++ b/src/components/Todo/index.jsx
@@ -1,14 +1,12 @@
 import React, { PropTypes } from 'react';
+import CSSModules from 'react-css-modules';
 
 import CallToAction from '../CallToAction';
+import styles from './styles.css';
 
 const Todo = ({ onClick, completed, callToAction }) => (
-  <li
-    onClick={onClick}
-    style={{
-      textDecoration: completed ? 'line-through' : 'none'
-    }}
-    >
+  <li onClick={onClick}
+      styleName={completed ? 'todo-completed' : 'todo'}>
     <CallToAction {...callToAction.data} uid={callToAction.uid} key={callToAction.uid} />
   </li>
 )
@@ -20,4 +18,4 @@ Todo.propTypes = {
   callToAction: PropTypes.object.isRequired
 }
 
-export default Todo
+export default CSSModules(Todo, styles);

--- a/src/components/Todo/index.jsx
+++ b/src/components/Todo/index.jsx
@@ -1,0 +1,23 @@
+import React, { PropTypes } from 'react';
+
+import CallToAction from '../CallToAction';
+
+const Todo = ({ onClick, completed, callToAction }) => (
+  <li
+    onClick={onClick}
+    style={{
+      textDecoration: completed ? 'line-through' : 'none'
+    }}
+    >
+    <CallToAction {...callToAction.data} uid={callToAction.uid} key={callToAction.uid} />
+  </li>
+)
+
+
+Todo.propTypes = {
+  onClick: PropTypes.func.isRequired,
+  completed: PropTypes.bool.isRequired,
+  callToAction: PropTypes.object.isRequired
+}
+
+export default Todo

--- a/src/components/Todo/styles.css
+++ b/src/components/Todo/styles.css
@@ -1,0 +1,14 @@
+.todo {
+  list-style-type: none;
+}
+.todo:before {
+  content: "☐";
+  position: absolute;
+}
+.todo-completed {
+  composes: todo;
+  text-decoration: line-through;
+}
+.todo-completed:before {
+  content: "☑";
+}

--- a/src/components/TodoList/index.jsx
+++ b/src/components/TodoList/index.jsx
@@ -1,0 +1,25 @@
+import React, { PropTypes } from 'react'
+import Todo from '../Todo'
+
+const TodoList = ({ todos, onTodoClick }) => (
+  <ul>
+    {todos.map(todo =>
+      <Todo
+         key={todo.uid}
+         {...todo}
+         onClick={() => onTodoClick(todo.uid)}
+         />
+    )}
+  </ul>
+)
+
+TodoList.propTypes = {
+  todos: PropTypes.arrayOf(PropTypes.shape({
+    uid: PropTypes.string.isRequired,
+    completed: PropTypes.bool.isRequired,
+    callToAction: PropTypes.object.isRequired
+  }).isRequired).isRequired,
+  onTodoClick: PropTypes.func.isRequired
+}
+
+export default TodoList

--- a/src/containers/AddTodo.js
+++ b/src/containers/AddTodo.js
@@ -1,0 +1,21 @@
+import { connect } from 'react-redux';
+import _ from 'lodash';
+
+import { addTodo } from '../actions';
+import AddTodoComponent from '../components/AddTodo';
+
+const mapStateToProps = (state, { actionId }) => (
+  { todo: _.find(state.todos, { actionId }) }
+);
+
+const mapDispatchToProps = dispatch => (
+  {
+    onClick: (actionId) => {
+      dispatch(addTodo(actionId));
+    },
+  }
+);
+
+const AddTodo = connect(mapStateToProps, mapDispatchToProps)(AddTodoComponent);
+
+export default AddTodo;

--- a/src/containers/TodoList.js
+++ b/src/containers/TodoList.js
@@ -1,0 +1,27 @@
+import { connect } from 'react-redux';
+import _ from 'lodash';
+
+import { toggleTodo } from '../actions';
+import TodoListComponent from '../components/TodoList';
+
+const mapStateToProps = state => (
+  {
+    todos: state.todos.map(todo => (
+      Object.assign({}, todo, {
+        callToAction: _.find(state.callsToAction, { uid: todo.actionId }),
+      })
+    )),
+  }
+);
+
+const mapDispatchToProps = dispatch => (
+  {
+    onTodoClick: (uid) => {
+      dispatch(toggleTodo(uid));
+    },
+  }
+);
+
+const TodoList = connect(mapStateToProps, mapDispatchToProps)(TodoListComponent);
+
+export default TodoList;

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -1,5 +1,38 @@
 // @flow
 
-export default function reducer(state: {} = {}) {
-  return state;
+import _ from 'lodash';
+import uuid from 'uuid';
+
+import { ADD_TODO, TOGGLE_TODO } from './actions';
+
+export default function reducer(state: {} = {}, action: {}) {
+  switch (action.type) {
+    case ADD_TODO:
+      if (_.find(state.todos, { actionId: action.actionId })) {
+        return state;
+      }
+      return Object.assign({}, state, {
+        todos: [
+          ...state.todos,
+          {
+            uid: uuid.v4(),
+            actionId: action.actionId,
+            completed: false,
+          },
+        ],
+      });
+    case TOGGLE_TODO:
+      return Object.assign({}, state, {
+        todos: state.todos.map((todo) => {
+          if (todo.uid === action.uid) {
+            return Object.assign({}, todo, {
+              completed: !todo.completed,
+            });
+          }
+          return todo;
+        }),
+      });
+    default:
+      return state;
+  }
 }

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -1,42 +1,52 @@
 // @flow
-
+import { combineReducers } from 'redux';
 import _ from 'lodash';
 import uuid from 'uuid';
 
 import { ADD_TODO, TOGGLE_TODO } from './actions';
 
-export default function reducer(
-  state: { todos: [] },
+function callsToAction(state: Array<{}> = []) {
+  return state;
+}
+
+function startHere(state: {} = {}) {
+  return state;
+}
+
+function todos(
+  state: Array<{uid: string, actionId: string, completed: boolean}> = [],
   action: {
     type: string, actionId?: string, uid?: string
   }) {
   switch (action.type) {
     case ADD_TODO:
-      if (_.find(state.todos, { actionId: action.actionId })) {
+      if (_.find(state, { actionId: action.actionId })) {
         return state;
       }
-      return Object.assign({}, state, {
-        todos: [
-          ...state.todos,
-          {
-            uid: uuid.v4(),
-            actionId: action.actionId,
-            completed: false,
-          },
-        ],
-      });
+      return [
+        ...state,
+        {
+          uid: uuid.v4(),
+          actionId: action.actionId,
+          completed: false,
+        },
+      ];
     case TOGGLE_TODO:
-      return Object.assign({}, state, {
-        todos: state.todos.map((todo) => {
-          if (todo.uid === action.uid) {
-            return Object.assign({}, todo, {
-              completed: !todo.completed,
-            });
-          }
-          return todo;
-        }),
+      return state.map((todo) => {
+        if (todo.uid === action.uid) {
+          return Object.assign({}, todo, {
+            completed: !todo.completed,
+          });
+        }
+        return todo;
       });
     default:
       return state;
   }
 }
+
+const app = combineReducers({
+  callsToAction, startHere, todos,
+});
+
+export default app;

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -5,7 +5,11 @@ import uuid from 'uuid';
 
 import { ADD_TODO, TOGGLE_TODO } from './actions';
 
-export default function reducer(state: {} = {}, action: {}) {
+export default function reducer(
+  state: { todos: [] },
+  action: {
+    type: string, actionId?: string, uid?: string
+  }) {
   switch (action.type) {
     case ADD_TODO:
       if (_.find(state.todos, { actionId: action.actionId })) {

--- a/src/routes.js
+++ b/src/routes.js
@@ -1,0 +1,6 @@
+const routes = {
+  '/': {},
+  '/todo': {},
+};
+
+export default routes;

--- a/src/server/prismicStore.js
+++ b/src/server/prismicStore.js
@@ -7,7 +7,6 @@ import logger from './logger';
 const cache = {
   callsToAction: [],
   startHere: {},
-  todos: [],
 };
 
 export default cache;

--- a/src/server/prismicStore.js
+++ b/src/server/prismicStore.js
@@ -7,6 +7,7 @@ import logger from './logger';
 const cache = {
   callsToAction: [],
   startHere: {},
+  todos: [],
 };
 
 export default cache;

--- a/src/server/renderSite.jsx
+++ b/src/server/renderSite.jsx
@@ -2,8 +2,9 @@
 
 import React from 'react';
 import { renderToString } from 'react-dom/server';
-import { createStore } from 'redux';
+import { createStore, compose, applyMiddleware } from 'redux';
 import { Provider } from 'react-redux';
+import { RouterProvider } from 'redux-little-router';
 
 import App from '../../build/App';
 import reducer from '../reducer';
@@ -43,16 +44,26 @@ function renderFullPage(html, preloadedState, includePrismicToolbar) {
   `;
 }
 
-export default function (preloadedState: {}, {
+export default function (
+  router: { routerEnhancer: {}, routerMiddleware: {} },
+  preloadedState: {}, {
   includePrismicToolbar,
 }: {
   includePrismicToolbar: boolean,
 } = {}) {
-  const store = createStore(reducer, preloadedState);
+  const store = createStore(reducer, preloadedState, 
+                            compose(
+                              router.routerEnhancer,
+                              applyMiddleware(
+                                router.routerMiddleware
+                              )
+                            ));
 
   const html = renderToString(
     <Provider store={store}>
-      <App />
+      <RouterProvider store={store}>
+        <App />
+      </RouterProvider>
     </Provider>,
   );
 


### PR DESCRIPTION
* Add `todo` array to state, which is only manipulated client-side and doesn't persist at all
  * each `todo` points to a CallToAction by slug, and each CTA can be added only once to the todo list
* Add actions and reducer to append a new todo and toggle `todo.completed`
* Add a button next to each CTA in the UI to add it to your todo list
* Display your to-do list at the bottom of the page
* Click on a to-do entry to complete/uncomplete it

Note: this doesn't really do anything yet, but wanted to push some code to see if I'm at least on the right track structure-wise before I go too much farther down this path. I think next steps are to wire up routing so that I can put the todo list on its own page, and then start making it less lazily ugly.