### PR TITLE
Add user interface for todo list

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -1,8 +1,8 @@
-export const ADD_TODO = 'ADD_TODO';
+export const ADD_TODOS = 'ADD_TODOS';
 export const ADD_OR_TOGGLE_TODO = 'ADD_OR_TOGGLE_TODO';
 
-export function addTodo(actionId, phoneNumbers) {
-  return { type: ADD_TODO, actionId, phoneNumbers };
+export function addTodos(actionId, phoneNumbers) {
+  return { type: ADD_TODOS, actionId, phoneNumbers };
 }
 
 export function addOrToggleTodo(actionId, phoneNumber) {

--- a/src/actions.js
+++ b/src/actions.js
@@ -1,13 +1,8 @@
 export const ADD_TODO = 'ADD_TODO';
-export const TOGGLE_TODO = 'TOGGLE_TODO';
 export const ADD_OR_TOGGLE_TODO = 'ADD_OR_TOGGLE_TODO';
 
 export function addTodo(actionId, phoneNumbers) {
   return { type: ADD_TODO, actionId, phoneNumbers };
-}
-
-export function toggleTodo(uid) {
-  return { type: TOGGLE_TODO, uid };
 }
 
 export function addOrToggleTodo(actionId, phoneNumber) {

--- a/src/actions.js
+++ b/src/actions.js
@@ -1,5 +1,6 @@
 export const ADD_TODO = 'ADD_TODO';
 export const TOGGLE_TODO = 'TOGGLE_TODO';
+export const ADD_OR_TOGGLE_TODO = 'ADD_OR_TOGGLE_TODO';
 
 export function addTodo(actionId, phoneNumbers) {
   return { type: ADD_TODO, actionId, phoneNumbers };
@@ -7,4 +8,8 @@ export function addTodo(actionId, phoneNumbers) {
 
 export function toggleTodo(uid) {
   return { type: TOGGLE_TODO, uid };
+}
+
+export function addOrToggleTodo(actionId, phoneNumber) {
+  return { type: ADD_OR_TOGGLE_TODO, actionId, phoneNumber };
 }

--- a/src/components/App/index.jsx
+++ b/src/components/App/index.jsx
@@ -11,12 +11,14 @@ import CallToAction from '../CallToAction';
 import StructuredText from '../StructuredText';
 import styles from './styles.css';
 
-const App = ({ callsToAction, startHere }) => (
+const App = ({ callsToAction, startHere, todos }) => (
   <div>
     <h1 id="title" styleName="title">{startHere.data['start-here.page-title'].value}</h1>
     <h2 styleName="subtitle">{startHere.data['start-here.subtitle'].value}</h2>
 
     <Fragment forRoute="/">
+      {todos && todos.length ? <Link styleName="link-button" href="/todo">To Dos</Link> : ''}
+
       <div id="intro" styleName="intro">
         <Link styleName="link-button" href="/start-here">{startHere.data['start-here.button-text'].value}</Link>
       </div>

--- a/src/components/App/styles.css
+++ b/src/components/App/styles.css
@@ -25,6 +25,7 @@ p {
 
 ul, li {
   margin: 1ex 0;
+  padding: 0;
 }
 
 a {

--- a/src/components/CallToAction/index.jsx
+++ b/src/components/CallToAction/index.jsx
@@ -8,10 +8,21 @@ import styles from './styles.css';
 
 const CallToAction = props => (
   <div styleName="call-to-action">
-    <AddTodo actionId={props.uid} phoneNumbers={props['call-to-action.phone-numbers']} />
-    <h1>{props['call-to-action.title'].value[0].text}</h1>
+    {
+      !props.inTodo &&
+      <AddTodo actionId={props.uid}
+               phoneNumbers={props['call-to-action.phone-numbers']} />
+    }
 
-    <time>{props['call-to-action.date'].value}</time>
+    {
+      !props.inTodo &&
+      <h1>{props['call-to-action.title'].value[0].text}</h1>
+    }
+
+    {
+      !props.inTodo &&
+      <time>{props['call-to-action.date'].value}</time>
+    }
 
     <div styleName="script">
       <StructuredText {...props['call-to-action.script']} />
@@ -21,14 +32,18 @@ const CallToAction = props => (
       <StructuredText {...props['call-to-action.notes']} />
     </div>
 
-    <div styleName="phone-numbers">
-      {props['call-to-action.phone-numbers'] && <PhoneNumbers value={props['call-to-action.phone-numbers'].value} actionId={props.uid} />}
-    </div>
+    {
+      !props.inTodo &&
+      <div styleName="phone-numbers">
+          {props['call-to-action.phone-numbers'] && <PhoneNumbers value={props['call-to-action.phone-numbers'].value} actionId={props.uid} />}
+      </div>
+    }
   </div>
 );
 
 CallToAction.propTypes = {
   uid: PropTypes.string.isRequired,
+  inTodo: PropTypes.bool,
   'call-to-action.title': PropTypes.object.isRequired,
   'call-to-action.notes': PropTypes.object,
   'call-to-action.script': PropTypes.object,

--- a/src/components/CallToAction/index.jsx
+++ b/src/components/CallToAction/index.jsx
@@ -20,12 +20,13 @@ const CallToAction = props => (
     </div>
 
     <div styleName="phone-numbers">
-      {props['call-to-action.phone-numbers'] && <PhoneNumbers {...props['call-to-action.phone-numbers']} />}
+      {props['call-to-action.phone-numbers'] && <PhoneNumbers value={props['call-to-action.phone-numbers'].value} actionId={props.uid} />}
     </div>
   </div>
 );
 
 CallToAction.propTypes = {
+  uid: PropTypes.string.isRequired,
   'call-to-action.title': PropTypes.object.isRequired,
   'call-to-action.notes': PropTypes.object,
   'call-to-action.script': PropTypes.object,

--- a/src/components/CallToAction/index.jsx
+++ b/src/components/CallToAction/index.jsx
@@ -1,12 +1,14 @@
 import React, { PropTypes } from 'react';
 import CSSModules from 'react-css-modules';
 
+import AddTodo from '../../containers/AddTodo';
 import StructuredText from '../StructuredText';
 import PhoneNumbers from '../PhoneNumbers';
 import styles from './styles.css';
 
 const CallToAction = props => (
   <div styleName="call-to-action">
+    <AddTodo actionId={props.uid} phoneNumbers={props['call-to-action.phone-numbers']} />
     <h1>{props['call-to-action.title'].value[0].text}</h1>
 
     <time>{props['call-to-action.date'].value}</time>

--- a/src/components/PhoneNumber/index.jsx
+++ b/src/components/PhoneNumber/index.jsx
@@ -3,9 +3,11 @@ import React, { PropTypes } from 'react';
 import _ from 'lodash';
 import phoneFormatter from 'phone-formatter';
 
+import ToggleTodo from '../../containers/ToggleTodo';
+
 import styles from './styles.css';
 
-function PhoneNumber({ value }) {
+function PhoneNumber({ value, actionId }) {
   const title = _.get(value, 'title.value');
   const firstName = _.get(value, 'first-name-or-organization.value');
   const lastName = _.get(value, 'last-name.value');
@@ -15,6 +17,7 @@ function PhoneNumber({ value }) {
 
   return (
     <div styleName="phone-number-block">
+      <ToggleTodo phoneNumber={value} actionId={actionId} />
       {name && <div styleName="name">{name}</div>}
       <div styleName="phone-number">{phone}</div>
     </div>
@@ -23,6 +26,7 @@ function PhoneNumber({ value }) {
 
 PhoneNumber.propTypes = {
   value: PropTypes.object.isRequired,
+  actionId: PropTypes.string.isRequired,
 };
 
 export default CSSModules(PhoneNumber, styles);

--- a/src/components/PhoneNumbers/index.jsx
+++ b/src/components/PhoneNumbers/index.jsx
@@ -5,16 +5,17 @@ import PhoneNumber from '../PhoneNumber';
 
 import styles from './styles.css';
 
-const PhoneNumbers = ({ value }) => (
+const PhoneNumbers = ({ value, actionId }) => (
   <div styleName="phone-numbers">
     {(value || []).map((number, i) => (
-      <PhoneNumber key={i} value={number} />
+       <PhoneNumber key={i} value={number} actionId={actionId} />
     ))}
   </div>
 );
 
 PhoneNumbers.propTypes = {
   value: PropTypes.array.isRequired,
+  actionId: PropTypes.string.isRequired,
 };
 
 export default CSSModules(PhoneNumbers, styles);

--- a/src/components/Todo/index.jsx
+++ b/src/components/Todo/index.jsx
@@ -6,9 +6,8 @@ import PhoneNumber from '../PhoneNumber';
 
 import styles from './styles.css';
 
-const Todo = ({ onClick, completed, target, callToAction }) => (
-  <li onClick={onClick}
-      styleName={completed ? 'todo-completed' : 'todo'}>
+const Todo = ({ completed, target, callToAction }) => (
+  <li styleName={completed ? 'todo-completed' : 'todo'}>
     <PhoneNumber value={target} actionId={callToAction.uid} />
     <div styleName={completed ? 'todo-completed-summary' : 'todo-summary'}>
       {callToAction.data['call-to-action.title'].value[0].text}
@@ -24,7 +23,6 @@ const Todo = ({ onClick, completed, target, callToAction }) => (
 
 
 Todo.propTypes = {
-  onClick: PropTypes.func.isRequired,
   completed: PropTypes.bool.isRequired,
   callToAction: PropTypes.object.isRequired,
   target: PropTypes.object.isRequired,

--- a/src/components/Todo/index.jsx
+++ b/src/components/Todo/index.jsx
@@ -13,11 +13,12 @@ const Todo = ({ onClick, completed, target, callToAction }) => (
     <div styleName={completed ? 'todo-completed-summary' : 'todo-summary'}>
       {callToAction.data['call-to-action.title'].value[0].text}
     </div>
-    <div styleName={completed ? 'todo-completed-call-to-action' : 'todo-call-to-action'}>
+    {!completed &&
       <CallToAction {...callToAction.data}
                     uid={callToAction.uid}
-                    key={callToAction.uid} />
-    </div>
+                    key={callToAction.uid}
+                    inTodo={true} />
+    }
   </li>
 )
 

--- a/src/components/Todo/index.jsx
+++ b/src/components/Todo/index.jsx
@@ -9,9 +9,15 @@ import styles from './styles.css';
 const Todo = ({ onClick, completed, target, callToAction }) => (
   <li onClick={onClick}
       styleName={completed ? 'todo-completed' : 'todo'}>
-      Call <PhoneNumber value={target} />:
+    <PhoneNumber value={target} actionId={callToAction.uid} />
+    <div styleName={completed ? 'todo-completed-summary' : 'todo-summary'}>
       {callToAction.data['call-to-action.title'].value[0].text}
-      <CallToAction {...callToAction.data} uid={callToAction.uid} key={callToAction.uid} />
+    </div>
+    <div styleName={completed ? 'todo-completed-call-to-action' : 'todo-call-to-action'}>
+      <CallToAction {...callToAction.data}
+                    uid={callToAction.uid}
+                    key={callToAction.uid} />
+    </div>
   </li>
 )
 

--- a/src/components/Todo/styles.css
+++ b/src/components/Todo/styles.css
@@ -2,12 +2,30 @@
   list-style-type: none;
 }
 .todo:before {
-  content: "☐";
 }
 .todo-completed {
   composes: todo;
   text-decoration: line-through;
 }
 .todo-completed:before {
-  content: "☑";
+}
+.todo h1,
+.todo time {
+  display: none;
+}
+.todo-completed-call-to-action {
+  display: none;
+}
+.todo-call-to-action {
+  text-decoration: none;
+}
+.todo-summary {
+  margin-left: 5vh;
+  margin-top: -1.5ex;
+  font-weight: bold;
+}
+.todo-completed-summary {
+  composes: todo-summary;
+  font-weight: normal;
+  font-style: italic;
 }

--- a/src/components/Todo/styles.css
+++ b/src/components/Todo/styles.css
@@ -7,15 +7,6 @@
   composes: todo;
   text-decoration: line-through;
 }
-.todo-completed:before {
-}
-.todo h1,
-.todo time {
-  display: none;
-}
-.todo-completed-call-to-action {
-  display: none;
-}
 .todo-call-to-action {
   text-decoration: none;
 }

--- a/src/components/TodoList/index.jsx
+++ b/src/components/TodoList/index.jsx
@@ -7,7 +7,6 @@ const TodoList = ({ todos, onTodoClick }) => (
       <Todo
          key={todo.uid}
          {...todo}
-         onClick={() => onTodoClick(todo.uid)}
          />
     )}
   </ul>
@@ -20,7 +19,6 @@ TodoList.propTypes = {
     callToAction: PropTypes.object.isRequired,
     target: PropTypes.object.isRequired,
   }).isRequired).isRequired,
-  onTodoClick: PropTypes.func.isRequired
 }
 
 export default TodoList

--- a/src/components/ToggleTodo/index.jsx
+++ b/src/components/ToggleTodo/index.jsx
@@ -1,0 +1,22 @@
+import React, { PropTypes } from 'react'
+import CSSModules from 'react-css-modules';
+
+import styles from './styles.css';
+
+const ToggleTodo = ({onClick, actionId, phoneNumber, todo}) => {
+  return (
+    <input type="checkbox"
+           styleName='toggle-todo'
+           onChange={function() {onClick(actionId, phoneNumber)}}
+           checked={todo && todo.completed} />
+  )
+}
+
+ToggleTodo.propTypes = {
+  onClick: PropTypes.func.isRequired,
+  actionId: PropTypes.string.isRequired,
+  phoneNumber: PropTypes.object.isRequired,
+  todo: PropTypes.object
+}
+
+export default CSSModules(ToggleTodo, styles);

--- a/src/components/ToggleTodo/index.jsx
+++ b/src/components/ToggleTodo/index.jsx
@@ -1,14 +1,20 @@
+// @flow
 import React, { PropTypes } from 'react'
 import CSSModules from 'react-css-modules';
 
 import styles from './styles.css';
+
+function shouldCheckToggle(todo: ?{completed: boolean}): boolean {
+  if (todo == null) return false;
+  return todo.completed;
+}
 
 const ToggleTodo = ({onClick, actionId, phoneNumber, todo}) => {
   return (
     <input type="checkbox"
            styleName='toggle-todo'
            onChange={function() {onClick(actionId, phoneNumber)}}
-           checked={todo && todo.completed} />
+           checked={shouldCheckToggle(todo)} />
   )
 }
 

--- a/src/components/ToggleTodo/styles.css
+++ b/src/components/ToggleTodo/styles.css
@@ -1,0 +1,3 @@
+.toggle-todo {
+
+}

--- a/src/containers/AddTodo.js
+++ b/src/containers/AddTodo.js
@@ -1,7 +1,7 @@
 import { connect } from 'react-redux';
 import _ from 'lodash';
 
-import { addTodo } from '../actions';
+import { addTodos } from '../actions';
 import AddTodoComponent from '../components/AddTodo';
 
 const mapStateToProps = (state, { actionId }) => (
@@ -11,7 +11,7 @@ const mapStateToProps = (state, { actionId }) => (
 const mapDispatchToProps = dispatch => (
   {
     onClick: (actionId, phoneNumbers) => {
-      dispatch(addTodo(actionId, phoneNumbers.value));
+      dispatch(addTodos(actionId, phoneNumbers.value));
     },
   }
 );

--- a/src/containers/TodoList.js
+++ b/src/containers/TodoList.js
@@ -1,7 +1,6 @@
 import { connect } from 'react-redux';
 import _ from 'lodash';
 
-import { toggleTodo } from '../actions';
 import TodoListComponent from '../components/TodoList';
 
 const mapStateToProps = state => (
@@ -14,12 +13,8 @@ const mapStateToProps = state => (
   }
 );
 
-const mapDispatchToProps = dispatch => (
-  {
-    onTodoClick: (uid) => {
-      dispatch(toggleTodo(uid));
-    },
-  }
+const mapDispatchToProps = () => (
+  {}
 );
 
 const TodoList = connect(mapStateToProps, mapDispatchToProps)(TodoListComponent);

--- a/src/containers/ToggleTodo.js
+++ b/src/containers/ToggleTodo.js
@@ -1,0 +1,23 @@
+import { connect } from 'react-redux';
+import _ from 'lodash';
+
+import { addOrToggleTodo } from '../actions';
+import ToggleTodoComponent from '../components/ToggleTodo';
+
+const mapStateToProps = (state, { actionId, phoneNumber }) => (
+  {
+    todo: _.find(state.todos, { actionId, target: phoneNumber }),
+  }
+);
+
+const mapDispatchToProps = dispatch => (
+  {
+    onClick: (actionId, phoneNumber) => {
+      dispatch(addOrToggleTodo(actionId, phoneNumber));
+    },
+  }
+);
+
+const ToggleTodo = connect(mapStateToProps, mapDispatchToProps)(ToggleTodoComponent);
+
+export default ToggleTodo;

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -3,7 +3,7 @@ import { combineReducers } from 'redux';
 import _ from 'lodash';
 import uuid from 'uuid';
 
-import { ADD_TODO, ADD_OR_TOGGLE_TODO } from './actions';
+import { ADD_TODOS, ADD_OR_TOGGLE_TODO } from './actions';
 
 function callsToAction(state: Array<{}> = []) {
   return state;
@@ -74,7 +74,7 @@ function todos(
       }
       return toggleTodo(addTodo(state, action.actionId, actionPhoneNumber),
                         action.actionId, actionPhoneNumber);
-    case ADD_TODO:
+    case ADD_TODOS:
       if (actionPhoneNumbers === null) {
         throw new Error("Can't add / toggle a todo without a phone number");
       }

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -65,19 +65,30 @@ function todos(
     phoneNumbers?: Array<{}>,
     phoneNumber?: {},
   }) {
+  const actionPhoneNumber = action.phoneNumber;
+  const actionPhoneNumbers = action.phoneNumbers;
   switch (action.type) {
     case ADD_OR_TOGGLE_TODO:
-      return toggleTodo(addTodo(state, action.actionId, action.phoneNumber),
-                        action.actionId, action.phoneNumber);
+      if (actionPhoneNumber == null) {
+        throw new Error("Can't add / toggle a todo without a phone number");
+      }
+      return toggleTodo(addTodo(state, action.actionId, actionPhoneNumber),
+                        action.actionId, actionPhoneNumber);
     case ADD_TODO:
-      return _.reduce((action.phoneNumbers || []),
+      if (actionPhoneNumbers === null) {
+        throw new Error("Can't add / toggle a todo without a phone number");
+      }
+      return _.reduce((actionPhoneNumbers || []),
                       (newState, phoneNumber) => (
                         addTodo(newState,
                                 action.actionId,
                                 phoneNumber)
                       ), state);
     case TOGGLE_TODO:
-      return toggleTodo(state, action.actionId, action.phoneNumber);
+      if (actionPhoneNumber == null) {
+        throw new Error("Can't add / toggle a todo without a phone number");
+      }
+      return toggleTodo(state, action.actionId, actionPhoneNumber);
     default:
       return state;
   }

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -3,7 +3,7 @@ import { combineReducers } from 'redux';
 import _ from 'lodash';
 import uuid from 'uuid';
 
-import { ADD_TODO, TOGGLE_TODO } from './actions';
+import { ADD_TODO, TOGGLE_TODO, ADD_OR_TOGGLE_TODO } from './actions';
 
 function callsToAction(state: Array<{}> = []) {
   return state;
@@ -13,6 +13,46 @@ function startHere(state: {} = {}) {
   return state;
 }
 
+function addTodo(
+  state: Array<{
+    uid: string,
+    target: {},
+    actionId: string,
+    completed: boolean}>,
+  actionId: string,
+  phoneNumber: {}) {
+  // If there are already todos for this action, do nothing
+  if (_.find(state, { actionId, target: phoneNumber })) {
+    return state;
+  }
+  return state.concat(
+    {
+      actionId,
+      target: phoneNumber,
+      uid: uuid.v4(),
+      completed: false,
+    },
+  );
+}
+
+function toggleTodo(
+  state: Array<{
+    uid: string,
+    target: {},
+    actionId: string,
+    completed: boolean}> = [],
+  actionId: string,
+  phoneNumber: {}) {
+  return state.map((todo) => {
+    if (todo.actionId === actionId && todo.target === phoneNumber) {
+      return Object.assign({}, todo, {
+        completed: !todo.completed,
+      });
+    }
+    return todo;
+  });
+}
+
 function todos(
   state: Array<{
     uid: string,
@@ -20,31 +60,24 @@ function todos(
     actionId: string,
     completed: boolean}> = [],
   action: {
-    type: string, actionId?: string, uid?: string, phoneNumbers?: Array<{}>,
+    type: string,
+    actionId: string, uid?: string,
+    phoneNumbers?: Array<{}>,
+    phoneNumber?: {},
   }) {
   switch (action.type) {
+    case ADD_OR_TOGGLE_TODO:
+      return toggleTodo(addTodo(state, action.actionId, action.phoneNumber),
+                        action.actionId, action.phoneNumber);
     case ADD_TODO:
-      // If there are already todos for this action, do nothing
-      if (_.find(state, { actionId: action.actionId })) {
-        return state;
-      }
-      return state.concat((action.phoneNumbers || []).map(phoneNumber => (
-        {
-          uid: uuid.v4(),
-          actionId: action.actionId,
-          completed: false,
-          target: phoneNumber,
-        }
-      )));
+      return _.reduce((action.phoneNumbers || []),
+                      (newState, phoneNumber) => (
+                        addTodo(newState,
+                                action.actionId,
+                                phoneNumber)
+                      ), state);
     case TOGGLE_TODO:
-      return state.map((todo) => {
-        if (todo.uid === action.uid) {
-          return Object.assign({}, todo, {
-            completed: !todo.completed,
-          });
-        }
-        return todo;
-      });
+      return toggleTodo(state, action.actionId, action.phoneNumber);
     default:
       return state;
   }

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -3,7 +3,7 @@ import { combineReducers } from 'redux';
 import _ from 'lodash';
 import uuid from 'uuid';
 
-import { ADD_TODO, TOGGLE_TODO, ADD_OR_TOGGLE_TODO } from './actions';
+import { ADD_TODO, ADD_OR_TOGGLE_TODO } from './actions';
 
 function callsToAction(state: Array<{}> = []) {
   return state;
@@ -84,11 +84,6 @@ function todos(
                                 action.actionId,
                                 phoneNumber)
                       ), state);
-    case TOGGLE_TODO:
-      if (actionPhoneNumber == null) {
-        throw new Error("Can't add / toggle a todo without a phone number");
-      }
-      return toggleTodo(state, action.actionId, actionPhoneNumber);
     default:
       return state;
   }


### PR DESCRIPTION
Work in progress, definitely not merge-ready!  Per discussion elsewhere --

* Let user cross off individual targets on a CTA directly from the home page
  * This creates a new todo entry, and marks it completed immediately upon creation
* Link to /todo page only after there are any todos to show
* Start working on styling for /todo page -- open items should be easy to review & read out the script, and completed items should be collapsed

I'm hitting a couple of walls here; if you have a few minutes to give me some pointers here or on slack, I'd be really grateful.  Notes/questions inline in comments, but the three topics I'm struggling with are controlled vs uncontrolled inputs, flow annotations for functions with conditional/varying expectations, and reusing components without entangling them too badly.